### PR TITLE
Update Hapticable.swift

### DIFF
--- a/Sources/Hapticable.swift
+++ b/Sources/Hapticable.swift
@@ -11,7 +11,7 @@ import UIKit
 private var hapticKey: Void?
 private var eventKey: Void?
 
-public protocol Hapticable {
+public protocol Hapticable: class {
     func trigger(_ sender: Any)
 }
 


### PR DESCRIPTION
'cannot assign to property' fix

<!-- Thanks for contributing to _Haptica_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
this change will solve `cannot assign to property: 'self' is immutable` error for cases when trying to assign property inside subclass c-tor
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
#### Sample code:
```swift
class MyButtonSubclass: UIButton {
    override init(frame: CGRect) {
        super.init(frame: frame)
        isHaptic = true
        hapticType = .impact(.heavy)
    }
}
```

