### PR TITLE
iOS 13 feedback types support

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,13 +20,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="elS-1Y-p46">
-                                <rect key="frame" x="93.5" y="197.5" width="188" height="272"/>
+                                <rect key="frame" x="30" y="197.5" width="315" height="272"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m90-YI-fCw">
-                                        <rect key="frame" x="0.0" y="0.0" width="188" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Selection Feedback" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cky-gV-ppP">
-                                                <rect key="frame" x="0.0" y="0.0" width="188" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -36,19 +34,19 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Ech-Z8-tuu">
-                                        <rect key="frame" x="0.0" y="30.5" width="188" height="30"/>
+                                        <rect key="frame" x="0.0" y="30.5" width="315" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Eac-Bx-Ar1">
-                                                <rect key="frame" x="0.0" y="0.0" width="188" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315" height="30"/>
                                                 <state key="normal" title="trigger"/>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H33-6S-0KR">
-                                        <rect key="frame" x="0.0" y="70.5" width="188" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="70.5" width="315" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Impact Feedback" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Ko-N8-Hl4">
-                                                <rect key="frame" x="0.0" y="0.0" width="188" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -56,27 +54,35 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Twy-Bl-h5f">
-                                        <rect key="frame" x="0.0" y="101" width="188" height="30"/>
+                                        <rect key="frame" x="0.0" y="101" width="315" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jik-rg-0ul">
-                                                <rect key="frame" x="0.0" y="0.0" width="56" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="55" height="30"/>
                                                 <state key="normal" title="light"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TGH-wQ-bf0">
-                                                <rect key="frame" x="66" y="0.0" width="56" height="30"/>
+                                                <rect key="frame" x="65" y="0.0" width="55" height="30"/>
                                                 <state key="normal" title="medium"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bED-Jo-DM0">
-                                                <rect key="frame" x="132" y="0.0" width="56" height="30"/>
+                                                <rect key="frame" x="130" y="0.0" width="55" height="30"/>
                                                 <state key="normal" title="heavy"/>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yls-TX-ZF1" userLabel="Impact Soft">
+                                                <rect key="frame" x="195" y="0.0" width="55" height="30"/>
+                                                <state key="normal" title="soft"/>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Pi-TW-eCZ" userLabel="Impact Rigid">
+                                                <rect key="frame" x="260" y="0.0" width="55" height="30"/>
+                                                <state key="normal" title="rigid"/>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6gy-B6-AgD">
-                                        <rect key="frame" x="0.0" y="141" width="188" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="141" width="315" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Notification Feedback" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Ir-wh-k4Y">
-                                                <rect key="frame" x="0.0" y="0.0" width="188" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -84,27 +90,27 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VtE-Br-YoR">
-                                        <rect key="frame" x="0.0" y="171.5" width="188" height="30"/>
+                                        <rect key="frame" x="0.0" y="171.5" width="315" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I55-pN-tPs">
-                                                <rect key="frame" x="0.0" y="0.0" width="56" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="98.5" height="30"/>
                                                 <state key="normal" title="success"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rvH-wW-1Pe">
-                                                <rect key="frame" x="66" y="0.0" width="56" height="30"/>
+                                                <rect key="frame" x="108.5" y="0.0" width="98" height="30"/>
                                                 <state key="normal" title="warning"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5eb-K5-ij8">
-                                                <rect key="frame" x="132" y="0.0" width="56" height="30"/>
+                                                <rect key="frame" x="216.5" y="0.0" width="98.5" height="30"/>
                                                 <state key="normal" title="error"/>
                                             </button>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dxs-sI-No8">
-                                        <rect key="frame" x="0.0" y="211.5" width="188" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="211.5" width="315" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vibration Pattern" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WSE-UQ-fUR">
-                                                <rect key="frame" x="0.0" y="0.0" width="188" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -112,10 +118,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Wy6-Zx-DIq">
-                                        <rect key="frame" x="0.0" y="242" width="188" height="30"/>
+                                        <rect key="frame" x="0.0" y="242" width="315" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6XI-uc-0Nv">
-                                                <rect key="frame" x="0.0" y="0.0" width="188" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="315" height="30"/>
                                                 <state key="normal" title="play"/>
                                                 <connections>
                                                     <action selector="playVibrationPattern:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mJt-KA-71l"/>
@@ -136,6 +142,8 @@
                         <outlet property="impactHeavy" destination="bED-Jo-DM0" id="yNA-Pe-a3j"/>
                         <outlet property="impactLight" destination="Jik-rg-0ul" id="KwH-9Q-UfN"/>
                         <outlet property="impactMedium" destination="TGH-wQ-bf0" id="aoC-dy-jei"/>
+                        <outlet property="impactRigid" destination="9Pi-TW-eCZ" id="QUy-1Q-fkX"/>
+                        <outlet property="impactSoft" destination="yls-TX-ZF1" id="4XM-5g-xLr"/>
                         <outlet property="notificationError" destination="5eb-K5-ij8" id="FrT-dq-i1E"/>
                         <outlet property="notificationSuccess" destination="I55-pN-tPs" id="SUj-9L-Del"/>
                         <outlet property="notificationWarning" destination="rvH-wW-1Pe" id="l8w-Ck-Yhf"/>
@@ -144,6 +152,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-78" y="120"/>
         </scene>
     </scenes>
 </document>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -34,6 +34,22 @@ class ViewController: UIViewController {
             impactHeavy.addHaptic(.impact(.heavy), forControlEvents: .touchDown)
         }
     }
+    
+    @IBOutlet weak var impactSoft: UIButton! {
+        didSet {
+            if #available(iOS 13.0, *) {
+                impactSoft.addHaptic(.impact(.soft), forControlEvents: .touchDown)
+            }
+        }
+    }
+
+    @IBOutlet weak var impactRigid: UIButton! {
+        didSet {
+            if #available(iOS 13.0, *) {
+                impactRigid.addHaptic(.impact(.rigid), forControlEvents: .touchDown)
+            }
+        }
+    }
 
     @IBOutlet weak var notificationSuccess: UIButton! {
         didSet {

--- a/Haptica.podspec
+++ b/Haptica.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Haptica'
-  s.version          = '3.0.1'
+  s.version          = '3.0.2'
   s.summary          = 'Easy Haptic Feedback'
   s.homepage         = 'https://github.com/efremidze/Haptica'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Haptica.xcodeproj/project.pbxproj
+++ b/Haptica.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.efremidze.Haptica;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -458,7 +458,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.efremidze.Haptica;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Sources/Haptic.swift
+++ b/Sources/Haptic.swift
@@ -10,6 +10,9 @@ import UIKit
 
 public enum HapticFeedbackStyle: Int {
     case light, medium, heavy
+    
+    @available(iOS 13.0, *)
+    case soft, rigid
 }
 
 @available(iOS 10.0, *)


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
Two new types of feedback intensity in iOS13 which are not handled or mapped in Haptica.

### Description
Added *soft* and *rigid* types of feedback and updated the example app.
